### PR TITLE
Add executable wrapper script

### DIFF
--- a/sandy.sh
+++ b/sandy.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Wrapper script for Sandy CLI.
+# Symlink this somewhere on your PATH:
+#   ln -s /path/to/sandy/sandy.sh /usr/local/bin/sandy
+set -euo pipefail
+
+SANDY_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+exec uv run --directory "$SANDY_DIR" sandy "$@"


### PR DESCRIPTION
## Summary
- Adds `sandy.sh` wrapper that resolves its own location through symlinks and delegates to `uv run sandy`
- Users can symlink it onto their PATH: `ln -s /path/to/sandy/sandy.sh /usr/local/bin/sandy`
- No more typing `uv run sandy ...` each time

## Test plan
- [x] Tested with no args (shows usage)
- [x] Tested with unmatched command (graceful "I don't know how to do that yet")
- [x] All 99 existing tests pass
- [x] `readlink -f` works on macOS and Debian

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)