### PR TITLE
fix: re-enable dispatch plugin on homelab with remote-aware fallback

### DIFF
--- a/sandy/plugins/dispatch.py
+++ b/sandy/plugins/dispatch.py
@@ -6,10 +6,14 @@ agents are launched.
 Commands:
   "dispatch status" / "status"  — current state from memory.md
   "dispatch check"  / "check"   — recent run activity and lock status
-  "dispatch inbox"  / "inbox"   — contents of PM Inbox.md
+  "dispatch pm"     / "pm"      — contents of PM Inbox.md
 
 The plugin reads files directly so it returns instantly, unlike the
 dispatch CLI modes that launch full Claude agent sessions.
+
+When Sandy is running remotely (e.g. homelab Docker container) and cannot
+reach the Mac's Dispatch files, each command returns a friendly explanation
+instead of the generic "I'm not sure how to do that" fallback.
 """
 
 from __future__ import annotations
@@ -22,10 +26,10 @@ name = "dispatch"
 commands = [
     "dispatch status",
     "dispatch check",
-    "dispatch inbox",
+    "dispatch pm",
     "status",
     "check",
-    "inbox",
+    "pm",
 ]
 
 # Default location — can be overridden by DISPATCH_OBSIDIAN_DIR env var
@@ -41,6 +45,17 @@ def _metaframework_dir() -> Path:
     return Path(os.environ.get("DISPATCH_METAFRAMEWORK_DIR", str(_DEFAULT_METAFRAMEWORK_DIR)))
 
 
+def _remote_context() -> bool:
+    """Return True if neither key Dispatch directory is reachable.
+
+    When Sandy is running on a remote host (e.g. homelab Docker container) the
+    Obsidian vault and metaframework checkout aren't mounted.  Rather than
+    returning raw path-not-found errors for every command, we detect this once
+    and return a friendly explanation.
+    """
+    return not _dispatch_dir().exists() and not _metaframework_dir().exists()
+
+
 # ---------------------------------------------------------------------------
 # status — summary from memory.md
 # ---------------------------------------------------------------------------
@@ -54,6 +69,15 @@ _STATUS_RE = re.compile(
 
 def _cmd_status() -> dict:
     """Read current status from Dispatch/memory.md."""
+    if _remote_context():
+        return {
+            "title": "Dispatch Status",
+            "text": (
+                "Sandy is running remotely and cannot reach Dispatch files on your Mac.\n"
+                "Check memory.md directly in Obsidian."
+            ),
+        }
+
     path = _dispatch_dir() / "memory.md"
     if not path.exists():
         return {"text": f"memory.md not found at {path}"}
@@ -81,6 +105,15 @@ def _cmd_status() -> dict:
 
 def _cmd_check() -> dict:
     """Show recent dispatch runs and lock status."""
+    if _remote_context():
+        return {
+            "title": "Dispatch Activity",
+            "text": (
+                "Sandy is running remotely and cannot reach Dispatch logs on your Mac.\n"
+                "Check the metaframework logs directory directly."
+            ),
+        }
+
     mf_dir = _metaframework_dir()
     logs_dir = mf_dir / "logs"
 
@@ -122,15 +155,24 @@ def _cmd_check() -> dict:
 
 
 # ---------------------------------------------------------------------------
-# inbox — PM Inbox contents
+# pm — PM Inbox contents
 # ---------------------------------------------------------------------------
 
 # Strip YAML-style metadata blocks from the top
 _FRONTMATTER_RE = re.compile(r"^---\n.*?\n---\n", re.DOTALL)
 
 
-def _cmd_inbox() -> dict:
+def _cmd_pm() -> dict:
     """Show the contents of PM Inbox.md."""
+    if _remote_context():
+        return {
+            "title": "PM Inbox",
+            "text": (
+                "Sandy is running remotely and cannot reach PM Inbox.md on your Mac.\n"
+                "Open PM Inbox.md directly in Obsidian."
+            ),
+        }
+
     path = _dispatch_dir() / "PM Inbox.md"
     if not path.exists():
         return {"text": f"PM Inbox.md not found at {path}"}
@@ -154,8 +196,8 @@ _DISPATCH: dict[str, str] = {
     "status": "_cmd_status",
     "dispatch check": "_cmd_check",
     "check": "_cmd_check",
-    "dispatch inbox": "_cmd_inbox",
-    "inbox": "_cmd_inbox",
+    "dispatch pm": "_cmd_pm",
+    "pm": "_cmd_pm",
 }
 
 

--- a/tests/test_dispatch_plugin.py
+++ b/tests/test_dispatch_plugin.py
@@ -17,7 +17,7 @@ import sandy.plugins.dispatch as dispatch_plugin
 
 @pytest.fixture()
 def dispatch_dir(tmp_path, monkeypatch):
-    """Redirect plugin to a temp dispatch dir."""
+    """Redirect plugin to a temp dispatch dir (simulates local Mac environment)."""
     monkeypatch.setenv("DISPATCH_OBSIDIAN_DIR", str(tmp_path))
     monkeypatch.setenv("DISPATCH_METAFRAMEWORK_DIR", str(tmp_path))
     return tmp_path
@@ -41,11 +41,35 @@ def test_commands_include_all_three():
     cmds = dispatch_plugin.commands
     assert "dispatch status" in cmds
     assert "dispatch check" in cmds
-    assert "dispatch inbox" in cmds
+    assert "dispatch pm" in cmds
     # short aliases
     assert "status" in cmds
     assert "check" in cmds
-    assert "inbox" in cmds
+    assert "pm" in cmds
+
+
+def test_commands_do_not_include_inbox():
+    cmds = dispatch_plugin.commands
+    assert "inbox" not in cmds
+    assert "dispatch inbox" not in cmds
+
+
+# ---------------------------------------------------------------------------
+# _remote_context
+# ---------------------------------------------------------------------------
+
+
+def test_remote_context_true_when_dirs_missing(monkeypatch, tmp_path):
+    """Returns True when neither dispatch dir nor metaframework dir exists."""
+    nonexistent = str(tmp_path / "does_not_exist")
+    monkeypatch.setenv("DISPATCH_OBSIDIAN_DIR", nonexistent)
+    monkeypatch.setenv("DISPATCH_METAFRAMEWORK_DIR", nonexistent)
+    assert dispatch_plugin._remote_context() is True
+
+
+def test_remote_context_false_when_dispatch_dir_exists(dispatch_dir):
+    """Returns False when the dispatch dir exists (even if metaframework dir doesn't)."""
+    assert dispatch_plugin._remote_context() is False
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +119,16 @@ def test_status_missing_file(dispatch_dir):
     assert "not found" in result["text"].lower()
 
 
+def test_status_remote_context(monkeypatch, tmp_path):
+    """Returns friendly message when running remotely."""
+    nonexistent = str(tmp_path / "does_not_exist")
+    monkeypatch.setenv("DISPATCH_OBSIDIAN_DIR", nonexistent)
+    monkeypatch.setenv("DISPATCH_METAFRAMEWORK_DIR", nonexistent)
+    result = dispatch_plugin._cmd_status()
+    assert result["title"] == "Dispatch Status"
+    assert "remotely" in result["text"].lower()
+
+
 # ---------------------------------------------------------------------------
 # _cmd_check
 # ---------------------------------------------------------------------------
@@ -130,12 +164,22 @@ def test_check_title():
     assert result.get("title") == "Dispatch Activity"
 
 
+def test_check_remote_context(monkeypatch, tmp_path):
+    """Returns friendly message when running remotely."""
+    nonexistent = str(tmp_path / "does_not_exist")
+    monkeypatch.setenv("DISPATCH_OBSIDIAN_DIR", nonexistent)
+    monkeypatch.setenv("DISPATCH_METAFRAMEWORK_DIR", nonexistent)
+    result = dispatch_plugin._cmd_check()
+    assert result["title"] == "Dispatch Activity"
+    assert "remotely" in result["text"].lower()
+
+
 # ---------------------------------------------------------------------------
-# _cmd_inbox
+# _cmd_pm
 # ---------------------------------------------------------------------------
 
 
-def test_inbox_shows_contents(dispatch_dir):
+def test_pm_shows_contents(dispatch_dir):
     _write(
         dispatch_dir / "PM Inbox.md",
         """\
@@ -144,20 +188,30 @@ def test_inbox_shows_contents(dispatch_dir):
         - [skill-request 2026-03-20]: Something useful
         """,
     )
-    result = dispatch_plugin._cmd_inbox()
+    result = dispatch_plugin._cmd_pm()
     assert result["title"] == "PM Inbox"
     assert "skill-request" in result["text"]
 
 
-def test_inbox_empty(dispatch_dir):
+def test_pm_empty(dispatch_dir):
     _write(dispatch_dir / "PM Inbox.md", "")
-    result = dispatch_plugin._cmd_inbox()
+    result = dispatch_plugin._cmd_pm()
     assert "empty" in result["text"].lower()
 
 
-def test_inbox_missing_file(dispatch_dir):
-    result = dispatch_plugin._cmd_inbox()
+def test_pm_missing_file(dispatch_dir):
+    result = dispatch_plugin._cmd_pm()
     assert "not found" in result["text"].lower()
+
+
+def test_pm_remote_context(monkeypatch, tmp_path):
+    """Returns friendly message when running remotely."""
+    nonexistent = str(tmp_path / "does_not_exist")
+    monkeypatch.setenv("DISPATCH_OBSIDIAN_DIR", nonexistent)
+    monkeypatch.setenv("DISPATCH_METAFRAMEWORK_DIR", nonexistent)
+    result = dispatch_plugin._cmd_pm()
+    assert result["title"] == "PM Inbox"
+    assert "remotely" in result["text"].lower()
 
 
 # ---------------------------------------------------------------------------
@@ -180,9 +234,14 @@ def test_handle_check(dispatch_dir, monkeypatch):
     assert dispatch_plugin.handle("check", "tom") == {"text": "check result"}
 
 
-def test_handle_inbox(dispatch_dir, monkeypatch):
-    monkeypatch.setattr(dispatch_plugin, "_cmd_inbox", lambda: {"text": "inbox result"})
-    assert dispatch_plugin.handle("inbox", "tom") == {"text": "inbox result"}
+def test_handle_pm(dispatch_dir, monkeypatch):
+    monkeypatch.setattr(dispatch_plugin, "_cmd_pm", lambda: {"text": "pm result"})
+    assert dispatch_plugin.handle("pm", "tom") == {"text": "pm result"}
+
+
+def test_handle_dispatch_pm(dispatch_dir, monkeypatch):
+    monkeypatch.setattr(dispatch_plugin, "_cmd_pm", lambda: {"text": "pm result"})
+    assert dispatch_plugin.handle("dispatch pm", "tom") == {"text": "pm result"}
 
 
 def test_handle_unknown_command():


### PR DESCRIPTION
## Summary
- Renames `inbox` → `pm` in dispatch plugin commands (aligns with current PM naming)
- Adds `_remote_context()` detection: when Sandy runs in Docker without Mac Dispatch files, returns a friendly explanation instead of the generic "Sorry, I'm not sure how to do that" no-match message
- 25 dispatch tests, 280 total — all pass

## Root cause
`sandy.toml.j2` on the homelab had `[dispatch] active = "no"` because the plugin previously had no fallback when Mac file paths weren't available. With the remote context detection added, it's safe to enable again.

## Test plan
- `uv run pytest --no-cov -q` → 280 passed
- `uv run sandy "check"` locally returns Dispatch Activity output
- Homelab Sandy will now respond to `check`, `status`, `pm` instead of "not sure how to do that"

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)