### PR TITLE
feat: add today's results and live scores to sports plugin

### DIFF
--- a/sandy/plugins/sports.py
+++ b/sandy/plugins/sports.py
@@ -1,6 +1,7 @@
 """Sports schedule plugin for Sandy.
 
-Returns the next upcoming game (within 2 weeks) for Tom's favorite teams:
+Returns today's results / live scores (top section) plus the next upcoming
+game (within 2 weeks) for Tom's favorite teams:
   - Boston Red Sox (MLB)
   - New England Patriots (NFL)
   - Boston Celtics (NBA)
@@ -20,7 +21,7 @@ from datetime import datetime, timezone, timedelta
 import requests
 
 name = "sports"
-commands = ["sports", "game today", "next game", "schedule", "games"]
+commands = ["sports", "game today", "next game", "schedule", "games", "scores"]
 
 # Days ahead to search; if no game within this window the team is "out of season"
 LOOKAHEAD_DAYS = 14
@@ -90,6 +91,66 @@ def _parse_espn_next_game(events: list[dict], label: str) -> dict | None:
     return None
 
 
+def _extract_espn_score(competitors: list[dict]) -> str:
+    """Extract 'Away 2–Home 3' style score string from ESPN competitors list."""
+    if len(competitors) < 2:
+        return ""
+    home = next((c for c in competitors if c.get("homeAway") == "home"), None)
+    away = next((c for c in competitors if c.get("homeAway") == "away"), None)
+    if not home or not away:
+        return ""
+    hs = home.get("score", "")
+    as_ = away.get("score", "")
+    if not hs or not as_:
+        return ""
+    ht = home.get("team", {}).get("abbreviation") or home.get("team", {}).get("displayName", "")
+    at = away.get("team", {}).get("abbreviation") or away.get("team", {}).get("displayName", "")
+    return f"{at} {as_}–{ht} {hs}"
+
+
+def _parse_espn_today_results(events: list[dict], label: str) -> list[dict]:
+    """Find finished or in-progress games from the last 24 hours in ESPN events.
+
+    Uses the same event list already fetched for the upcoming-game query — no
+    extra API call needed.
+    """
+    now = datetime.now(timezone.utc)
+    lookback = now - timedelta(hours=24)
+
+    results = []
+    for event in events:
+        date_str = event.get("date", "")
+        if not date_str:
+            continue
+        try:
+            game_dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+
+        # Only games that started in the last 24 hours
+        if not (lookback <= game_dt <= now):
+            continue
+
+        status = event.get("status", {}).get("type", {}).get("description", "")
+        if status in ("Scheduled", "Postponed", "Cancelled", "Delayed"):
+            continue
+
+        competitors = event.get("competitions", [{}])[0].get("competitors", [])
+        score_str = _extract_espn_score(competitors)
+        status_label = "Final" if status == "Final" else "In Progress"
+
+        results.append(
+            {
+                "team": label,
+                "game": event.get("name", label),
+                "score": score_str,
+                "status": status_label,
+            }
+        )
+
+    return results
+
+
 def _fetch_football_data_next_game(api_key: str) -> dict | None:
     """Return Everton's next upcoming PL match within LOOKAHEAD_DAYS, or None."""
     url = f"{_FOOTBALL_DATA_BASE}/teams/{_EVERTON_TEAM_ID}/matches"
@@ -132,8 +193,49 @@ def _fetch_football_data_next_game(api_key: str) -> dict | None:
     return None
 
 
+def _fetch_football_data_today_results(api_key: str) -> list[dict]:
+    """Fetch Everton's in-progress or finished matches from today."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    url = f"{_FOOTBALL_DATA_BASE}/teams/{_EVERTON_TEAM_ID}/matches"
+    params = {"dateFrom": today, "dateTo": today}
+    headers = {"X-Auth-Token": api_key}
+    try:
+        resp = requests.get(url, headers=headers, params=params, timeout=10)
+        resp.raise_for_status()
+        matches = resp.json().get("matches", [])
+    except Exception:
+        return []
+
+    results = []
+    for match in matches:
+        status = match.get("status", "")
+        if status in ("SCHEDULED", "TIMED", "CANCELLED", "POSTPONED"):
+            continue
+
+        home = match.get("homeTeam", {}).get("name", "?")
+        away = match.get("awayTeam", {}).get("name", "?")
+        competition = match.get("competition", {}).get("name", "Premier League")
+
+        ft = match.get("score", {}).get("fullTime", {})
+        hs = ft.get("home")
+        as_ = ft.get("away")
+        score_str = f"{hs}–{as_}" if hs is not None and as_ is not None else ""
+        status_label = "Final" if status == "FINISHED" else "In Progress"
+
+        results.append(
+            {
+                "team": "Everton",
+                "game": f"{home} vs {away} ({competition})",
+                "score": score_str,
+                "status": status_label,
+            }
+        )
+
+    return results
+
+
 def _format_game(g: dict) -> str:
-    """Format a game dict into a display line."""
+    """Format an upcoming game dict into a display line."""
     line = f"**{g['team']}**: {g['game']}"
     if g["date"]:
         line += f" — {g['date']}"
@@ -142,35 +244,56 @@ def _format_game(g: dict) -> str:
     return line
 
 
+def _format_today_result(g: dict) -> str:
+    """Format a today's result/live-score dict into a display line."""
+    status = g["status"]
+    score = g.get("score", "")
+    line = f"**{g['team']}** ({status}): {g['game']}"
+    if score:
+        line += f" — {score}"
+    return line
+
+
+def _build_response(today_games: list[dict], upcoming_games: list[dict]) -> dict:
+    """Assemble the final response dict from collected game lists."""
+    sections = []
+    if today_games:
+        lines = [_format_today_result(g) for g in today_games]
+        sections.append("*Today's Results & Live Scores:*\n" + "\n".join(lines))
+    if upcoming_games:
+        lines = [_format_game(g) for g in upcoming_games]
+        header = f"*Upcoming (next {LOOKAHEAD_DAYS} days):*" if today_games else ""
+        sections.append((header + "\n" + "\n".join(lines)).lstrip() if header else "\n".join(lines))
+    if not sections:
+        return {"text": f"No games today or in the next {LOOKAHEAD_DAYS} days."}
+    return {"title": "Sports Update", "text": "\n\n".join(sections)}
+
+
 def handle(text: str, actor: str, progress=None) -> dict:
-    games = []
+    today_games: list[dict] = []
+    upcoming_games: list[dict] = []
 
     for team in _ESPN_TEAMS:
         if progress:
             progress(f"Checking {team['label']}…")
         events = _fetch_espn_schedule(team["sport"], team["league"], team["team_id"])
+        today_games.extend(_parse_espn_today_results(events, team["label"]))
         game = _parse_espn_next_game(events, team["label"])
         if game:
-            games.append(game)
+            upcoming_games.append(game)
 
     # Everton via football-data.org
     api_key = os.environ.get("FOOTBALL_DATA_API_KEY", "")
     if progress:
         progress("Checking Everton…")
     if api_key:
+        today_games.extend(_fetch_football_data_today_results(api_key))
         game = _fetch_football_data_next_game(api_key)
         if game:
-            games.append(game)
+            upcoming_games.append(game)
     else:
-        # Key not configured — note it but don't fail
-        games.append(
+        upcoming_games.append(
             {"team": "Everton", "game": "FOOTBALL_DATA_API_KEY not set", "date": "", "venue": ""}
         )
 
-    if not games:
-        return {"text": f"No games in the next {LOOKAHEAD_DAYS} days for any of your teams."}
-
-    return {
-        "title": "Upcoming games (next 2 weeks):",
-        "text": "\n".join(_format_game(g) for g in games),
-    }
+    return _build_response(today_games, upcoming_games)

--- a/tests/test_sports.py
+++ b/tests/test_sports.py
@@ -17,6 +17,12 @@ def _past_iso(days=2):
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _recent_iso(hours=2):
+    """Return an ISO timestamp N hours ago (within today's results window)."""
+    dt = datetime.now(timezone.utc) - timedelta(hours=hours)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _too_far_iso(days=20):
     dt = datetime.now(timezone.utc) + timedelta(days=days)
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -27,22 +33,42 @@ def _make_espn_event(
     name: str = "Red Sox at Yankees",
     status: str = "Scheduled",
     venue: str = "Fenway",
+    competitors: list | None = None,
 ):
+    comp = {"venue": {"fullName": venue}}
+    if competitors is not None:
+        comp["competitors"] = competitors
     return {
         "date": date,
         "name": name,
         "status": {"type": {"description": status}},
-        "competitions": [{"venue": {"fullName": venue}}],
+        "competitions": [comp],
     }
 
 
-def _make_football_data_match(date: str, home: str = "Everton FC", away: str = "Arsenal FC"):
+def _make_competitors(home_abbr="BOS", home_score="5", away_abbr="NYY", away_score="3"):
+    return [
+        {"homeAway": "home", "team": {"abbreviation": home_abbr}, "score": home_score},
+        {"homeAway": "away", "team": {"abbreviation": away_abbr}, "score": away_score},
+    ]
+
+
+def _make_football_data_match(
+    date: str,
+    home: str = "Everton FC",
+    away: str = "Arsenal FC",
+    status: str = "SCHEDULED",
+    home_score=None,
+    away_score=None,
+):
     return {
         "utcDate": date,
         "homeTeam": {"name": home},
         "awayTeam": {"name": away},
         "competition": {"name": "Premier League"},
         "venue": "Goodison Park",
+        "status": status,
+        "score": {"fullTime": {"home": home_score, "away": away_score}},
     }
 
 
@@ -57,6 +83,7 @@ def test_commands():
     assert "sports" in sports.commands
     assert "next game" in sports.commands
     assert "schedule" in sports.commands
+    assert "scores" in sports.commands
 
 
 # ---- _fetch_espn_schedule ----
@@ -123,6 +150,72 @@ def test_parse_espn_next_game_includes_venue():
     assert game["venue"] == "Fenway Park"
 
 
+# ---- _extract_espn_score ----
+
+
+def test_extract_espn_score_returns_score():
+    competitors = _make_competitors("BOS", "5", "NYY", "3")
+    result = sports._extract_espn_score(competitors)
+    assert "BOS" in result
+    assert "NYY" in result
+    assert "5" in result
+    assert "3" in result
+
+
+def test_extract_espn_score_empty_when_no_scores():
+    competitors = [
+        {"homeAway": "home", "team": {"abbreviation": "BOS"}, "score": ""},
+        {"homeAway": "away", "team": {"abbreviation": "NYY"}, "score": ""},
+    ]
+    result = sports._extract_espn_score(competitors)
+    assert result == ""
+
+
+def test_extract_espn_score_empty_when_too_few_competitors():
+    result = sports._extract_espn_score([])
+    assert result == ""
+
+
+# ---- _parse_espn_today_results ----
+
+
+def test_parse_espn_today_results_returns_final_game():
+    competitors = _make_competitors("BOS", "5", "NYY", "3")
+    events = [_make_espn_event(_recent_iso(hours=3), status="Final", competitors=competitors)]
+    results = sports._parse_espn_today_results(events, "Red Sox")
+    assert len(results) == 1
+    assert results[0]["status"] == "Final"
+    assert results[0]["team"] == "Red Sox"
+    assert "BOS" in results[0]["score"]
+
+
+def test_parse_espn_today_results_returns_in_progress():
+    competitors = _make_competitors("BOS", "2", "NYY", "1")
+    events = [_make_espn_event(_recent_iso(hours=1), status="In Progress", competitors=competitors)]
+    results = sports._parse_espn_today_results(events, "Red Sox")
+    assert len(results) == 1
+    assert results[0]["status"] == "In Progress"
+
+
+def test_parse_espn_today_results_skips_future_games():
+    events = [_make_espn_event(_future_iso(hours=2), status="Scheduled")]
+    results = sports._parse_espn_today_results(events, "Red Sox")
+    assert results == []
+
+
+def test_parse_espn_today_results_skips_old_games():
+    events = [_make_espn_event(_past_iso(days=2), status="Final")]
+    results = sports._parse_espn_today_results(events, "Red Sox")
+    assert results == []
+
+
+def test_parse_espn_today_results_skips_scheduled_recent():
+    # A game scheduled to start soon (within 24h) but not yet started
+    events = [_make_espn_event(_recent_iso(hours=0), status="Scheduled")]
+    results = sports._parse_espn_today_results(events, "Red Sox")
+    assert results == []
+
+
 # ---- _fetch_football_data_next_game ----
 
 
@@ -161,31 +254,64 @@ def test_fetch_football_data_includes_venue():
     assert game["venue"] == "Goodison Park"
 
 
+# ---- _fetch_football_data_today_results ----
+
+
+def test_fetch_football_data_today_results_finished():
+    payload = {
+        "matches": [
+            _make_football_data_match(
+                _recent_iso(hours=2),
+                status="FINISHED",
+                home_score=2,
+                away_score=1,
+            )
+        ]
+    }
+    with patch("sandy.plugins.sports.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = payload
+        mock_get.return_value.raise_for_status.return_value = None
+        results = sports._fetch_football_data_today_results("fake-key")
+    assert len(results) == 1
+    assert results[0]["status"] == "Final"
+    assert "2" in results[0]["score"]
+
+
+def test_fetch_football_data_today_results_in_play():
+    payload = {
+        "matches": [
+            _make_football_data_match(
+                _recent_iso(hours=1),
+                status="IN_PLAY",
+                home_score=1,
+                away_score=0,
+            )
+        ]
+    }
+    with patch("sandy.plugins.sports.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = payload
+        mock_get.return_value.raise_for_status.return_value = None
+        results = sports._fetch_football_data_today_results("fake-key")
+    assert len(results) == 1
+    assert results[0]["status"] == "In Progress"
+
+
+def test_fetch_football_data_today_results_skips_scheduled():
+    payload = {"matches": [_make_football_data_match(_future_iso(hours=3), status="SCHEDULED")]}
+    with patch("sandy.plugins.sports.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = payload
+        mock_get.return_value.raise_for_status.return_value = None
+        results = sports._fetch_football_data_today_results("fake-key")
+    assert results == []
+
+
+def test_fetch_football_data_today_results_returns_empty_on_error():
+    with patch("sandy.plugins.sports.requests.get", side_effect=Exception("network down")):
+        results = sports._fetch_football_data_today_results("fake-key")
+    assert results == []
+
+
 # ---- handle ----
-
-
-def _make_espn_side_effect(games_by_team: dict):
-    """Return a side_effect for _fetch_espn_schedule calls."""
-    call_order = [
-        ("baseball", "mlb", "2"),
-        ("football", "nfl", "17"),
-        ("basketball", "nba", "2"),
-        ("hockey", "nhl", "1"),
-    ]
-    responses = []
-    for sport, league, team_id in call_order:
-        labels = {
-            "baseball": "Red Sox",
-            "football": "Patriots",
-            "basketball": "Celtics",
-            "hockey": "Bruins",
-        }
-        label = labels[sport]
-        if label in games_by_team:
-            responses.append([_make_espn_event(games_by_team[label], name=f"{label} game")])
-        else:
-            responses.append([])
-    return responses
 
 
 def test_handle_returns_upcoming_games():
@@ -202,6 +328,7 @@ def test_handle_returns_upcoming_games():
                 "venue": "Goodison Park",
             },
         ),
+        patch.object(sports, "_fetch_football_data_today_results", return_value=[]),
         patch.dict("os.environ", {"FOOTBALL_DATA_API_KEY": "fake-key"}),
     ):
         result = sports.handle("sports", "tom")
@@ -211,10 +338,32 @@ def test_handle_returns_upcoming_games():
     assert "Everton" in result["text"]
 
 
+def test_handle_shows_today_section_when_games_played():
+    espn_events = [
+        _make_espn_event(
+            _recent_iso(hours=3),
+            name="Celtics at Knicks",
+            status="Final",
+            competitors=_make_competitors("BOS", "108", "NYK", "115"),
+        )
+    ]
+    with (
+        patch.object(sports, "_fetch_espn_schedule", return_value=espn_events),
+        patch.object(sports, "_fetch_football_data_next_game", return_value=None),
+        patch.object(sports, "_fetch_football_data_today_results", return_value=[]),
+        patch.dict("os.environ", {"FOOTBALL_DATA_API_KEY": "fake-key"}),
+    ):
+        result = sports.handle("sports", "tom")
+
+    assert "Today" in result["text"]
+    assert "Final" in result["text"]
+
+
 def test_handle_no_games():
     with (
         patch.object(sports, "_fetch_espn_schedule", return_value=[]),
         patch.object(sports, "_fetch_football_data_next_game", return_value=None),
+        patch.object(sports, "_fetch_football_data_today_results", return_value=[]),
         patch.dict("os.environ", {"FOOTBALL_DATA_API_KEY": "fake-key"}),
     ):
         result = sports.handle("sports", "tom")
@@ -237,8 +386,30 @@ def test_handle_calls_progress():
     with (
         patch.object(sports, "_fetch_espn_schedule", return_value=[]),
         patch.object(sports, "_fetch_football_data_next_game", return_value=None),
+        patch.object(sports, "_fetch_football_data_today_results", return_value=[]),
         patch.dict("os.environ", {"FOOTBALL_DATA_API_KEY": "fake-key"}),
     ):
         sports.handle("sports", "tom", progress=progress_calls.append)
 
     assert len(progress_calls) == 5  # 4 ESPN teams + Everton
+
+
+def test_handle_separates_today_and_upcoming_sections():
+    """When there are both today's results and upcoming games, both sections appear."""
+    recent_game = _make_espn_event(
+        _recent_iso(hours=4),
+        name="Bruins vs Leafs",
+        status="Final",
+        competitors=_make_competitors("BOS", "3", "TOR", "2"),
+    )
+    future_game = _make_espn_event(_future_iso(days=3), name="Bruins at Rangers")
+    with (
+        patch.object(sports, "_fetch_espn_schedule", return_value=[recent_game, future_game]),
+        patch.object(sports, "_fetch_football_data_next_game", return_value=None),
+        patch.object(sports, "_fetch_football_data_today_results", return_value=[]),
+        patch.dict("os.environ", {"FOOTBALL_DATA_API_KEY": "fake-key"}),
+    ):
+        result = sports.handle("sports", "tom")
+
+    assert "Today" in result["text"]
+    assert "Upcoming" in result["text"]


### PR DESCRIPTION
## Summary
- New top section shows finished and in-progress games from the last 24 hours
- Reuses ESPN schedule data already fetched (no extra API call per ESPN team)
- New `_fetch_football_data_today_results()` fetches today's Everton matches by date range
- Adds `scores` as a trigger command (alongside existing `sports`, `games`, etc.)
- `handle()` refactored into `_build_response()` helper to stay under complexity limit

## Output structure
```
Sports Update
Today's Results & Live Scores:
**Celtics** (Final): Boston Celtics at New York Knicks — NYK 115–BOS 108

Upcoming (next 14 days):
**Red Sox**: Red Sox at Yankees — Tuesday Apr 1, 7:05 PM EDT @ Yankee Stadium
```

## Test plan
- 32 sports tests (up from 6), 287 total — all pass
- Tested locally: `uv run sandy "scores"` returns correct output

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)