### PR TITLE
feat: install sibling entry-point packages in restart.sh

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -20,6 +20,9 @@ echo "Syncing dependencies..."
 cd "$SCRIPT_DIR"
 uv sync --quiet
 
+echo "Installing sibling entry-point packages..."
+uv pip install -e ../itguy -e ../irs --quiet 2>/dev/null || true
+
 echo "Restarting sandy service..."
 systemctl --user restart sandy
 


### PR DESCRIPTION
## Summary

- After `uv sync`, restart.sh now runs `uv pip install -e ../itguy -e ../irs` to register sibling entry-point plugins in Sandy's venv
- Enables PR #76's entry-point plugin discovery to find itguy and estimatedtaxes on the homelab
- Fails silently if sibling repos aren't present

## Test plan

- [ ] Deploy to homelab: pull sandy, run `./restart.sh`
- [ ] Verify `uv run sandy "health"` lists itguy and estimatedtaxes plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)