### PR TITLE
fix: health plugin now shows entry-point plugins

### DIFF
--- a/sandy/plugins/health.py
+++ b/sandy/plugins/health.py
@@ -8,11 +8,10 @@ Commands:
 
 from __future__ import annotations
 
-import importlib.util
-import os
 from pathlib import Path
 
-from sandy.config import is_active, load_config
+from sandy.config import load_config
+from sandy.loader import load_plugins
 
 name = "health"
 commands = ["health"]
@@ -24,32 +23,15 @@ def _plugin_dir() -> Path:
 
 def handle(text: str, actor: str) -> dict:
     """Return a summary of all loaded plugins and their commands."""
-    plugin_dir = _plugin_dir()
     config = load_config()
-
-    filenames = sorted(
-        f for f in os.listdir(plugin_dir) if f.endswith(".py") and f != "__init__.py"
-    )
+    plugins = load_plugins(str(_plugin_dir()), config)
 
     plugin_summaries: list[str] = []
-    for filename in filenames:
-        filepath = plugin_dir / filename
-        try:
-            module_name = f"_health_inspect_{filename}"
-            spec = importlib.util.spec_from_file_location(module_name, filepath)
-            if spec is None or spec.loader is None:
-                continue
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            plugin_name = getattr(module, "name", filename.removesuffix(".py"))
-            if not is_active(config, plugin_name):
-                continue
-            plugin_commands = getattr(module, "commands", [])
-            if plugin_commands:
-                cmds = ", ".join(f"`{c}`" for c in plugin_commands)
-                plugin_summaries.append(f"• *{plugin_name}*: {cmds}")
-        except Exception:
-            continue
+    for plugin in plugins:
+        plugin_commands = getattr(plugin, "commands", [])
+        if plugin_commands:
+            cmds = ", ".join(f"`{c}`" for c in plugin_commands)
+            plugin_summaries.append(f"• *{plugin.name}*: {cmds}")
 
     if plugin_summaries:
         lines = ["*Active plugins:*"] + plugin_summaries


### PR DESCRIPTION
## Summary

- Health plugin was scanning `sandy/plugins/*.py` directly instead of using `load_plugins()`, so entry-point plugins (itguy, estimatedtaxes) were missing from health output
- Now delegates to `load_plugins()` which discovers both file-based and entry-point plugins

## Test plan

- [x] All 332 tests pass, 85.56% coverage
- [ ] `sandy "health"` in Slack shows itguy and estimatedtaxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)