### PR TITLE
chore: gitignore .coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.pyc
 .venv/
 *.egg-info/
+.coverage
 
 # Override global gitignore — uv.lock is needed for Docker build (uv sync --frozen)
 !uv.lock


### PR DESCRIPTION
## Summary

- Add `.coverage` to `.gitignore` so pytest-cov output stops showing as untracked
- Remove orphaned `assets/vintage-logo-backup.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)