### PR TITLE
restart.sh: uv sync --frozen (deploy idempotency)

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -18,7 +18,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Syncing dependencies..."
 cd "$SCRIPT_DIR"
-uv sync --quiet
+# --frozen: install from uv.lock as-is; do NOT re-resolve/rewrite the lock.
+# Without it, floor-pinned deps (e.g. aiohttp >=x) get upgraded on every run,
+# dirtying the tracked uv.lock — which breaks idempotency for the Ansible
+# native-apps deploy (its git clone reverts the lock, flapping every run).
+# Deploys should run the locked versions; bump deps by re-locking + committing.
+uv sync --frozen --quiet
 
 echo "Installing sibling entry-point packages..."
 uv pip install -e ../itguy -e ../irs --quiet 2>/dev/null || true


### PR DESCRIPTION
uv sync re-resolved floor-pinned deps (aiohttp >=3.13.5 → 3.14.0) and rewrote
the tracked uv.lock on every run. The homelab native-apps Ansible role clones
sandy with force: true, so the rewritten lock got reverted each deploy —
flapping (changed=2) and needlessly restarting sandy every run. --frozen
installs the locked versions as-is; bump deps by re-locking + committing.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
