### PR TITLE
fix: fail loudly when homelab sibling plugins go missing on deploy

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -25,8 +25,25 @@ cd "$SCRIPT_DIR"
 # Deploys should run the locked versions; bump deps by re-locking + committing.
 uv sync --frozen --quiet
 
-echo "Installing sibling entry-point packages..."
-uv pip install -e ../itguy -e ../irs --quiet 2>/dev/null || true
+echo "Installing sibling entry-point plugins..."
+# itguy/estimatedtaxes are homelab-only plugins that live outside sandy's
+# lockfile, so `uv sync --frozen` prunes them every run — reinstall explicitly.
+# Fail LOUDLY: a silent skip ships Sandy without the tax/itguy commands (the
+# old `|| true 2>/dev/null` hid exactly that). Siblings are absent in CI / dev
+# checkouts that don't have them — skip those cleanly. `set -e` aborts the
+# deploy before the restart if a present sibling won't install, and the daemon's
+# SANDY_REQUIRED_PLUGINS startup check reports any miss to Sentry on restart.
+sibling_specs=()
+for sib in ../itguy ../irs; do
+    if [ -d "$sib" ]; then
+        sibling_specs+=(-e "$sib")
+    else
+        echo "  (skipping $sib — not present)"
+    fi
+done
+if [ ${#sibling_specs[@]} -gt 0 ]; then
+    uv pip install "${sibling_specs[@]}"
+fi
 
 echo "Restarting sandy service..."
 systemctl --user restart sandy

--- a/sandy/daemon.py
+++ b/sandy/daemon.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from sandy.config import apply_env, find_config_path, load_config
 from sandy.loader import load_plugins
 from sandy import oauth_server
-from sandy.observability import init_sentry, status_message
+from sandy.observability import capture, init_sentry, status_message
 from sandy.pipeline import run_pipeline
 from sandy.printer import _DEFAULT_PRINTER, _is_ipp_uri, print_pdf
 from sandy.progress import QueueProgressReporter
@@ -33,6 +33,17 @@ def _plugin_snapshot(plugin_dir: str) -> dict[str, float]:
     return {
         str(p): p.stat().st_mtime for p in Path(plugin_dir).glob("*.py") if p.name != "__init__.py"
     }
+
+
+def _missing_required_plugins(loaded_names: set[str], required_csv: str) -> list[str]:
+    """Return required plugin names (from a comma-separated list) that didn't load.
+
+    ``required_csv`` comes from ``SANDY_REQUIRED_PLUGINS`` — names that *must* be
+    present in a given deployment (e.g. the homelab's entry-point plugins itguy
+    and estimatedtaxes, which a botched ``uv sync --frozen`` can silently prune).
+    """
+    required = [name.strip() for name in required_csv.split(",") if name.strip()]
+    return [name for name in required if name not in loaded_names]
 
 
 class Daemon:
@@ -58,9 +69,29 @@ class Daemon:
         logger.info(
             "Loaded %d content plugin(s): %s", len(self.plugins), [p.name for p in self.plugins]
         )
+        self._alert_on_missing_required_plugins()
         self.transports = load_transports(transport_dir, config)
         logger.info(
             "Loaded %d transport(s): %s", len(self.transports), [t.name for t in self.transports]
+        )
+
+    def _alert_on_missing_required_plugins(self) -> None:
+        """Loudly flag (log + Sentry) any SANDY_REQUIRED_PLUGINS that didn't load.
+
+        A deployment can silently come up missing entry-point plugins (e.g. the
+        homelab siblings itguy/estimatedtaxes pruned by ``uv sync --frozen``).
+        This turns that into a visible startup alert instead of a quiet outage.
+        """
+        loaded = {p.name for p in self.plugins}
+        missing = _missing_required_plugins(loaded, os.environ.get("SANDY_REQUIRED_PLUGINS", ""))
+        if not missing:
+            return
+        joined = ", ".join(missing)
+        logger.error("Required plugin(s) not loaded: %s (loaded: %s)", joined, sorted(loaded))
+        capture(
+            f"Required Sandy plugin(s) not loaded: {joined}",
+            source="startup",
+            missing=joined,
         )
 
     async def handle_message(

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -7,7 +7,73 @@ from unittest.mock import patch
 
 import pytest
 
-from sandy.daemon import Daemon, _plugin_snapshot
+from sandy.daemon import Daemon, _missing_required_plugins, _plugin_snapshot
+
+
+# ---------------------------------------------------------------------------
+# _missing_required_plugins
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_plugins_lists_absent_names():
+    assert _missing_required_plugins({"a", "b"}, "a, c ,d") == ["c", "d"]
+
+
+def test_missing_required_plugins_empty_when_all_present():
+    assert _missing_required_plugins({"a", "b"}, "a,b") == []
+
+
+def test_missing_required_plugins_empty_when_unset():
+    assert _missing_required_plugins({"a"}, "") == []
+
+
+def test_daemon_reports_missing_required_plugin_to_sentry(tmp_path, monkeypatch, sentry_events):
+    """A required plugin that fails to load fires a Sentry alert at startup."""
+    monkeypatch.setenv("SANDY_REQUIRED_PLUGINS", "echo,itguy")
+    plugin_dir = _make_plugins(
+        tmp_path,
+        "plugins",
+        {
+            "echo.py": """
+            name = "echo"
+            commands = ["echo"]
+            def handle(text, actor):
+                return {"text": "ok"}
+        """
+        },
+    )
+
+    Daemon(plugin_dir=plugin_dir, transport_dir=str(tmp_path / "transports"))
+
+    import sentry_sdk
+
+    sentry_sdk.flush()
+    assert len(sentry_events) == 1
+    assert "itguy" in sentry_events[0]["message"]
+    assert sentry_events[0]["tags"]["missing"] == "itguy"
+
+
+def test_daemon_silent_when_all_required_plugins_present(tmp_path, monkeypatch, sentry_events):
+    monkeypatch.setenv("SANDY_REQUIRED_PLUGINS", "echo")
+    plugin_dir = _make_plugins(
+        tmp_path,
+        "plugins",
+        {
+            "echo.py": """
+            name = "echo"
+            commands = ["echo"]
+            def handle(text, actor):
+                return {"text": "ok"}
+        """
+        },
+    )
+
+    Daemon(plugin_dir=plugin_dir, transport_dir=str(tmp_path / "transports"))
+
+    import sentry_sdk
+
+    sentry_sdk.flush()
+    assert sentry_events == []
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Follow-up to #129/#130. While verifying the Sentry fix, a restart silently dropped the `itguy` and `estimatedtaxes` (`irs`) commands — surfacing a latent deploy bug.

## Root cause
`itguy`/`estimatedtaxes` are **entry-point plugins** from installed sibling packages (`../itguy`, `../irs`) that live **outside** sandy's `uv.lock`. The deploy's `uv sync --frozen` prunes anything not in the lock, so it removes them every run. `restart.sh` re-installed them afterward — but as:

```bash
uv pip install -e ../itguy -e ../irs --quiet 2>/dev/null || true
```

…which swallows every error. So if that step fails (or a restart bypasses `restart.sh` entirely), Sandy comes up missing `tax`/`itguy` with **zero signal**.

## Why not just make them `uv` path-deps?
`[tool.uv.sources]` path deps would persist them through `uv sync --frozen`, but they'd be baked into `pyproject.toml`/`uv.lock` — which breaks `uv sync`/`uv lock` anywhere the siblings aren't checked out, **notably GitHub CI** (clones only sandy). So the explicit post-sync editable install is the right pattern for these homelab-only plugins; it just has to be loud and verified.

## Fix — defense in depth
1. **`restart.sh` fails loudly**: install only siblings that exist (skip cleanly in CI/dev), and let `set -e` abort the deploy **before** the restart if a present sibling won't install. No swallowed errors. Verified: install-OK reaches restart; install-fail aborts with exit 1 before restart.
2. **Daemon startup self-check → Sentry**: `SANDY_REQUIRED_PLUGINS` (comma-separated) lists plugins that must load in a given deployment. Any missing → `logger.error` **+ `capture()` to Sentry** (reuses #129's infra). Fires regardless of cause — botched deploy, manual restart, or an install that "succeeded" but didn't register. This alert would have fired the moment the restart dropped the plugins.

## Requires (homelab, separate repo)
Add `SANDY_REQUIRED_PLUGINS=itguy,estimatedtaxes` to the Ansible-Vault EnvironmentFile template (`~/.config/sandy/environment`). Without it the check is inert (correct for dev/CI).

## Tests
467 pass, 86% coverage. New: `_missing_required_plugins` unit tests + daemon-startup Sentry-alert integration tests (missing → one tagged event; all-present → silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)