### PR TITLE
fix(ci): register the inline-comment MCP server so reviews actually post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -67,6 +67,20 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'metaframework-dispatch-bot'
+          # REQUIRED to post inline comments, and the non-obvious one.
+          # `--allowed-tools` only FILTERS already-registered MCP servers; it does
+          # not register them. Without track_progress the github_inline_comment
+          # server never connects, so the inline-comment tool is denied even when
+          # it is correctly allow-listed — the model burns turns retrying and the
+          # job exits `success` having posted nothing. That was run 30504269713:
+          # authenticated fine, initialized on claude-sonnet-5, logged
+          # `No buffered inline comments`, left zero comments on PR #162.
+          track_progress: true
+          # Defaults to true, and has documented buffering bugs when enabled --
+          # the upstream examples/pr-review-comprehensive.yml omits it. Pinned
+          # off explicitly so a default change upstream can't silently reintroduce
+          # the empty-buffer failure above.
+          classify_inline_comments: false
           prompt: |
             Review this pull request for:
             - Code quality and best practices
@@ -76,5 +90,17 @@ jobs:
             - Test coverage
 
             Use the repository's CLAUDE.md for guidance on style and conventions.
-            Be constructive and specific. Use `gh pr comment` to leave your review.
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+            Be constructive and specific.
+
+            Post findings that point at specific lines with
+            mcp__github_inline_comment__create_inline_comment. Use `gh pr comment`
+            for the overall summary, or for findings with no single line to anchor
+            to. Say so in the summary if you find nothing worth flagging, so a
+            silent pass is distinguishable from a broken run.
+          # mcp__github_inline_comment__create_inline_comment must be listed here
+          # AND registered by track_progress above -- both, or inline comments
+          # silently no-op. --max-turns bounds the blast radius: an unposted
+          # finding otherwise retries until the turn limit, burning Actions
+          # minutes on a job that produces nothing (the account has exhausted its
+          # included minutes two months running).
+          claude_args: '--allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)" --max-turns 25'


### PR DESCRIPTION
The review job has been authenticating correctly and posting nothing.

## Evidence

Run [30504269713](https://github.com/tclancy/sandy/actions/runs/30504269713) — an `issue_comment` `/review` on PR #162 — got its app token, passed the actor check (`admin`), logged `Trigger result: true`, initialized Claude Code on `claude-sonnet-5`, then logged `No buffered inline comments` and exited `success` having left **zero** comments on the PR.

So `CLAUDE_CODE_OAUTH_TOKEN` is working — the secret propagation fixed #160's original failure. This is a second, independent problem underneath it.

## Cause

Two missing config layers, and the second is the non-obvious one:

| Layer | Missing | Effect |
|---|---|---|
| 2 | `mcp__github_inline_comment__create_inline_comment` absent from `--allowed-tools` | tool denied |
| 3 | `track_progress: true` absent | the `github_inline_comment` **MCP server is never registered** |

**`--allowed-tools` only filters already-registered MCP servers — it does not register them.** So fixing layer 2 alone would not have helped: the tool would still be denied while sitting correctly in the allow-list, the model would burn turns retrying, and the job would end quietly. `No buffered inline comments` is that signature.

## Changes

- `track_progress: true` — registers the inline-comment server (layer 3)
- inline-comment tool added to `--allowed-tools` (layer 2)
- `classify_inline_comments: false` — it defaults to **true** and has documented buffering bugs; upstream's own `examples/pr-review-comprehensive.yml` omits it. Pinned off so an upstream default change can't silently reintroduce the empty-buffer failure.
- `--max-turns 25` — bounds the retry burn. An unpostable finding otherwise loops to the turn limit, spending Actions minutes on a job that produces nothing, and this account has exhausted its included minutes two months running.
- Prompt now tells the model to anchor line-specific findings inline, and to **state explicitly when it finds nothing** — so a silent pass is distinguishable from a broken run. That ambiguity is what let this hide.

Comments explaining each are inline in the workflow, matching this file's existing habit — the `cancel-in-progress: false` comment is why we didn't re-break that during this work.

## Not changed

`allowed_bots` stays scoped to `metaframework-dispatch-bot` rather than `*`. sandy is public, and widening bot access here isn't needed to fix the current failure.

## This PR cannot verify itself

The action refuses to run when `claude-code-review.yml` on the PR head differs from the default branch's copy — an anti-tamper guard so a PR can't rewrite its own reviewer. It logs `Workflow validation failed` / `Action skipped due to workflow validation error` **while still exiting `success`**, so the job looks green having done nothing.

Merge this, then `/review` an unrelated open PR — `issue_comment` runs the default branch's copy, which is why that's the valid test.

## Follow-up, not in this PR

A burn audit found two related gaps in sibling repos:

- **`canvasoptimizer`** has `cancel-in-progress: true` — the exact setting this file's comment says MUST stay `false`. 10 review runs were measured cancelled mid-flight, billing partial minutes and never posting.
- **`antiquarian/.github/workflows/review.yml`** is a differently-named review workflow with none of the burn reductions, and it's invisible to a `--filename claude-code-review.yml` search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
